### PR TITLE
주문 날짜 연관관계 매핑

### DIFF
--- a/src/main/kotlin/com/example/custard/domain/order/dto/info/OrderCreateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/info/OrderCreateInfo.kt
@@ -2,20 +2,19 @@ package com.example.custard.domain.order.dto.info
 
 import com.example.custard.domain.order.enums.OrderPosition
 import com.example.custard.domain.order.model.Order
-import com.example.custard.domain.common.date.dto.DateInfo
 import com.example.custard.domain.post.model.Post
 import com.example.custard.domain.user.model.User
 
 class OrderCreateInfo (
     val postId: Long,
     val price: Int,
-    val date: DateInfo,
+    val dates: List<OrderDateInfo>,
 ) {
     companion object {
         fun toEntity(info: OrderCreateInfo, post: Post, requester: User, responder: User): Order {
             val roleRequester = if (post.isSale()) OrderPosition.CLIENT else OrderPosition.CREATOR
             val roleResponder = if (post.isSale()) OrderPosition.CREATOR else OrderPosition.CLIENT
-            return Order(post, requester, responder, roleRequester, roleResponder, info.price, DateInfo.toEntity(info.date))
+            return Order(post, requester, responder, roleRequester, roleResponder, info.price)
         }
     }
 }

--- a/src/main/kotlin/com/example/custard/domain/order/dto/info/OrderDateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/info/OrderDateInfo.kt
@@ -1,0 +1,17 @@
+package com.example.custard.domain.order.dto.info
+
+import com.example.custard.domain.order.model.Order
+import com.example.custard.domain.order.model.OrderDate
+import java.time.LocalDate
+import java.time.LocalTime
+
+class OrderDateInfo (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    companion object {
+        fun toEntity(info: OrderDateInfo, order: Order): OrderDate {
+            return OrderDate(order, info.date, info.time)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/order/dto/request/OrderCreateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/request/OrderCreateRequest.kt
@@ -1,14 +1,15 @@
 package com.example.custard.domain.order.dto.request
 
 import com.example.custard.domain.order.dto.info.OrderCreateInfo
-import com.example.custard.domain.common.date.dto.DateRequest
+import com.example.custard.domain.order.dto.info.OrderDateInfo
 
 class OrderCreateRequest (
     val postId: Long,
     val price: Int,
-    val date: DateRequest,
+    val dates: List<OrderDateRequest>,
 ) {
     fun createInfo(): OrderCreateInfo {
-        return OrderCreateInfo(postId, price, date.createInfo())
+        val dates: List<OrderDateInfo> = dates.map { it.createInfo() }
+        return OrderCreateInfo(postId, price, dates)
     }
 }

--- a/src/main/kotlin/com/example/custard/domain/order/dto/request/OrderDateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/request/OrderDateRequest.kt
@@ -1,0 +1,14 @@
+package com.example.custard.domain.order.dto.request
+
+import com.example.custard.domain.order.dto.info.OrderDateInfo
+import java.time.LocalDate
+import java.time.LocalTime
+
+class OrderDateRequest (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    fun createInfo(): OrderDateInfo {
+        return OrderDateInfo(date, time)
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/order/dto/response/OrderDateResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/response/OrderDateResponse.kt
@@ -1,0 +1,16 @@
+package com.example.custard.domain.order.dto.response
+
+import com.example.custard.domain.order.model.OrderDate
+import java.time.LocalDate
+import java.time.LocalTime
+
+class OrderDateResponse (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    companion object {
+        fun of(date: OrderDate): OrderDateResponse {
+            return OrderDateResponse(date.date, date.time)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/order/dto/response/OrderResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/dto/response/OrderResponse.kt
@@ -2,7 +2,6 @@ package com.example.custard.domain.order.dto.response
 
 import com.example.custard.domain.order.enums.OrderStatus
 import com.example.custard.domain.order.model.Order
-import com.example.custard.domain.common.date.dto.DateResponse
 import com.example.custard.domain.post.dto.response.PostSimpleResponse
 import com.example.custard.domain.user.dto.response.UserResponse
 
@@ -12,19 +11,20 @@ class OrderResponse (
     val requester: UserResponse,
     val responder: UserResponse,
     val price: Int,
-    val date: DateResponse,
+    val dates: List<OrderDateResponse>,
     val status: OrderStatus,
     val isRequest: Boolean,
 ) {
     companion object {
         fun of(order: Order, isRequest: Boolean): OrderResponse {
+            val dates: List<OrderDateResponse> = order.dates.map { OrderDateResponse.of(it) }
             return OrderResponse(
                 orderId = order.id,
                 post = PostSimpleResponse.of(order.post),
                 requester = UserResponse.of(order.requester),
                 responder = UserResponse.of(order.responder),
                 price = order.price,
-                date = DateResponse.of(order.date),
+                dates = dates,
                 status = order.status,
                 isRequest = isRequest
             )

--- a/src/main/kotlin/com/example/custard/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/model/Order.kt
@@ -5,7 +5,6 @@ import com.example.custard.domain.order.enums.OrderStatus
 import com.example.custard.domain.order.exception.InvalidOrderStateException
 import com.example.custard.domain.order.exception.OrderForbiddenException
 import com.example.custard.domain.post.model.Post
-import com.example.custard.domain.common.date.Date
 import com.example.custard.domain.user.model.User
 import jakarta.persistence.*
 
@@ -18,7 +17,6 @@ class Order (
     roleRequester: OrderPosition,
     roleResponder: OrderPosition,
     price: Int,
-    date: Date,
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
@@ -37,14 +35,18 @@ class Order (
 
     var price: Int = price
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    var date: Date = date
+    @OneToMany(mappedBy = "order", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val dates: MutableList<OrderDate> = mutableListOf()
 
     var status: OrderStatus = OrderStatus.WAITING
 
-    fun updateOrder(price: Int, date: Date) {
+    fun updateDates(dates: MutableList<OrderDate>) {
+        this.dates.retainAll(dates)
+        this.dates.addAll(dates)
+    }
+    fun updateOrder(price: Int, dates: MutableList<OrderDate>) {
         this.price = price
-        this.date = date
+        updateDates(dates)
     }
 
     fun confirmOrder(responder: User, accept: Boolean) {

--- a/src/main/kotlin/com/example/custard/domain/order/model/OrderDate.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/model/OrderDate.kt
@@ -1,0 +1,23 @@
+package com.example.custard.domain.order.model
+
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Entity
+class OrderDate (
+    order: Order,
+    date: LocalDate,
+    time: LocalTime?,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+   @ManyToOne(fetch = FetchType.LAZY)
+    val order: Order = order
+
+    val date: LocalDate = date
+
+    val time: LocalTime? = time
+}

--- a/src/main/kotlin/com/example/custard/domain/post/dto/info/DateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/info/DateInfo.kt
@@ -1,0 +1,16 @@
+package com.example.custard.domain.post.dto.info
+
+import com.example.custard.domain.post.model.Date
+import java.time.LocalDate
+import java.time.LocalTime
+
+class DateInfo(
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    companion object {
+        fun toEntity(info: DateInfo): Date {
+            return Date(info.date, info.time)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/post/dto/info/PostCreateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/info/PostCreateInfo.kt
@@ -1,6 +1,5 @@
 package com.example.custard.domain.post.dto.info
 
-import com.example.custard.domain.common.date.dto.DateInfo
 import com.example.custard.domain.post.model.Category
 import com.example.custard.domain.post.model.Post
 import com.example.custard.domain.post.model.PostType

--- a/src/main/kotlin/com/example/custard/domain/post/dto/info/PostUpdateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/info/PostUpdateInfo.kt
@@ -1,7 +1,5 @@
 package com.example.custard.domain.post.dto.info
 
-import com.example.custard.domain.common.date.dto.DateInfo
-
 open class PostUpdateInfo (
     val id: Long,
     val categoryId: Long,

--- a/src/main/kotlin/com/example/custard/domain/post/dto/request/DateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/request/DateRequest.kt
@@ -1,0 +1,14 @@
+package com.example.custard.domain.post.dto.request
+
+import com.example.custard.domain.post.dto.info.DateInfo
+import java.time.LocalDate
+import java.time.LocalTime
+
+class DateRequest (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    fun createInfo(): DateInfo {
+        return DateInfo(date, time)
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/post/dto/request/PostCreateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/request/PostCreateRequest.kt
@@ -1,8 +1,7 @@
 package com.example.custard.domain.post.dto.request
 
+import com.example.custard.domain.post.dto.info.DateInfo
 import com.example.custard.domain.post.dto.info.PostCreateInfo
-import com.example.custard.domain.common.date.dto.DateInfo
-import com.example.custard.domain.common.date.dto.DateRequest
 import com.example.custard.domain.post.model.PostType
 
 class PostCreateRequest (

--- a/src/main/kotlin/com/example/custard/domain/post/dto/request/PostUpdateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/request/PostUpdateRequest.kt
@@ -1,7 +1,6 @@
 package com.example.custard.domain.post.dto.request
 
-import com.example.custard.domain.common.date.dto.DateInfo
-import com.example.custard.domain.common.date.dto.DateRequest
+import com.example.custard.domain.post.dto.info.DateInfo
 import com.example.custard.domain.post.dto.info.PostUpdateInfo
 
 class PostUpdateRequest (

--- a/src/main/kotlin/com/example/custard/domain/post/dto/response/DateResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/response/DateResponse.kt
@@ -1,0 +1,16 @@
+package com.example.custard.domain.post.dto.response
+
+import com.example.custard.domain.post.model.Date
+import java.time.LocalDate
+import java.time.LocalTime
+
+class DateResponse (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    companion object {
+        fun of(date: Date): DateResponse {
+            return DateResponse(date.date, date.time)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/post/dto/response/PostDetailResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/response/PostDetailResponse.kt
@@ -1,6 +1,5 @@
 package com.example.custard.domain.post.dto.response
 
-import com.example.custard.domain.common.date.dto.DateResponse
 import com.example.custard.domain.post.model.Post
 import com.example.custard.domain.post.model.PostType
 import com.example.custard.domain.user.dto.response.UserResponse

--- a/src/main/kotlin/com/example/custard/domain/post/dto/response/PostResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/dto/response/PostResponse.kt
@@ -1,6 +1,5 @@
 package com.example.custard.domain.post.dto.response
 
-import com.example.custard.domain.common.date.dto.DateResponse
 import com.example.custard.domain.post.model.Post
 import com.example.custard.domain.post.model.PostType
 import com.example.custard.domain.user.dto.response.UserResponse

--- a/src/main/kotlin/com/example/custard/domain/post/repository/date/DateStoreImpl.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/repository/date/DateStoreImpl.kt
@@ -1,8 +1,8 @@
 package com.example.custard.domain.post.repository.date;
 
+import com.example.custard.domain.post.dto.info.DateInfo
 import com.example.custard.domain.post.model.Date
 import com.example.custard.domain.post.service.date.DateStore
-import com.example.custard.domain.common.date.dto.DateInfo
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 

--- a/src/main/kotlin/com/example/custard/domain/post/service/PostService.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/service/PostService.kt
@@ -2,7 +2,6 @@ package com.example.custard.domain.post.service
 
 import com.example.custard.domain.post.model.Date
 import com.example.custard.domain.post.service.date.DateStore
-import com.example.custard.domain.common.date.dto.DateInfo
 import com.example.custard.domain.post.dto.info.*
 import com.example.custard.domain.post.dto.response.PostDetailResponse
 import com.example.custard.domain.post.dto.response.PostResponse

--- a/src/main/kotlin/com/example/custard/domain/post/service/date/DateStore.kt
+++ b/src/main/kotlin/com/example/custard/domain/post/service/date/DateStore.kt
@@ -1,6 +1,6 @@
 package com.example.custard.domain.post.service.date
 
-import com.example.custard.domain.common.date.dto.DateInfo
+import com.example.custard.domain.post.dto.info.DateInfo
 import com.example.custard.domain.post.model.Date
 
 interface DateStore {


### PR DESCRIPTION
📌 주문 날짜 연관관계 매핑

- 주문이 포함하는 날짜 정보를 담는 엔티티 구현 (OrderDate)
- OrderDate의 경우, 시간을 포함하는 경우 / 포함하지 않는 경우가 존재하므로 date와 time으로 분리