### PR TITLE
제안 날짜 연관관계 매핑

### DIFF
--- a/src/main/kotlin/com/example/custard/domain/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/custard/domain/order/service/OrderService.kt
@@ -102,8 +102,7 @@ class OrderService (
 
         proposal.validateProposal(order, user)
 
-        // TODO: Date, Time of Proposal 수정
-        val date: OrderDate = OrderDate(order, proposal.date.toLocalDate(), null)
+        val date: OrderDate = OrderDate(order, proposal.date.date, proposal.date.time)
 
         order.updateOrder(proposal.price, mutableListOf(date))
 

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/info/ProposalCreateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/info/ProposalCreateInfo.kt
@@ -1,6 +1,5 @@
 package com.example.custard.domain.proposal.dto.info
 
-import com.example.custard.domain.common.date.dto.DateInfo
 import com.example.custard.domain.order.model.Order
 import com.example.custard.domain.proposal.model.Proposal
 import com.example.custard.domain.user.model.User
@@ -8,12 +7,12 @@ import com.example.custard.domain.user.model.User
 class ProposalCreateInfo (
     val orderId: Long,
     val price: Int,
-    val date: DateInfo,
+    val date: ProposalDateInfo,
     val message: String,
 ) {
     companion object {
         fun toEntity(info: ProposalCreateInfo, order: Order, sender: User, receiver: User): Proposal {
-            return Proposal(order, sender, receiver, info.price, DateInfo.toEntity(info.date), info.message)
+            return Proposal(order, sender, receiver, info.price, info.date.date, info.date.time, info.message)
         }
     }
 }

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/info/ProposalDateInfo.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/info/ProposalDateInfo.kt
@@ -1,0 +1,10 @@
+package com.example.custard.domain.proposal.dto.info
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ProposalDateInfo (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+}

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/request/ProposalCreateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/request/ProposalCreateRequest.kt
@@ -1,12 +1,11 @@
 package com.example.custard.domain.proposal.dto.request
 
-import com.example.custard.domain.common.date.dto.DateRequest
 import com.example.custard.domain.proposal.dto.info.ProposalCreateInfo
 
 class ProposalCreateRequest (
     val orderId: Long,
     val price: Int,
-    val date: DateRequest,
+    val date: ProposalDateRequest,
     val message: String,
 ) {
     fun createInfo(): ProposalCreateInfo {

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/request/ProposalDateRequest.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/request/ProposalDateRequest.kt
@@ -1,0 +1,14 @@
+package com.example.custard.domain.proposal.dto.request
+
+import com.example.custard.domain.proposal.dto.info.ProposalDateInfo
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ProposalDateRequest (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+    fun createInfo(): ProposalDateInfo {
+        return ProposalDateInfo(date, time)
+    }
+}

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/response/ProposalDateResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/response/ProposalDateResponse.kt
@@ -1,0 +1,10 @@
+package com.example.custard.domain.proposal.dto.response
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ProposalDateResponse (
+    val date: LocalDate,
+    val time: LocalTime?,
+) {
+}

--- a/src/main/kotlin/com/example/custard/domain/proposal/dto/response/ProposalResponse.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/dto/response/ProposalResponse.kt
@@ -1,15 +1,15 @@
 package com.example.custard.domain.proposal.dto.response
 
-import com.example.custard.domain.common.date.dto.DateResponse
 import com.example.custard.domain.proposal.enums.ProposalStatus
 import com.example.custard.domain.proposal.model.Proposal
 import com.example.custard.domain.user.dto.response.UserResponse
+import java.time.LocalDateTime
 
 class ProposalResponse (
     val proposalId: Long,
     val sender: UserResponse,
     val price: Int,
-    val date: DateResponse,
+    val date: ProposalDateResponse,
     val message: String?,
     val status: ProposalStatus,
 ) {
@@ -19,7 +19,7 @@ class ProposalResponse (
                 proposalId = proposal.id,
                 sender = UserResponse.of(proposal.sender),
                 price = proposal.price,
-                date = DateResponse.of(proposal.date),
+                date = ProposalDateResponse(proposal.date.date, proposal.date.time),
                 message = proposal.message,
                 status = proposal.status,
             )

--- a/src/main/kotlin/com/example/custard/domain/proposal/model/ProposalDate.kt
+++ b/src/main/kotlin/com/example/custard/domain/proposal/model/ProposalDate.kt
@@ -1,0 +1,12 @@
+package com.example.custard.domain.proposal.model
+
+import jakarta.persistence.Embeddable
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Embeddable
+class ProposalDate (
+    var date: LocalDate,
+    var time: LocalTime?,
+) {
+}


### PR DESCRIPTION
📌 제안 날짜 연관관계 매핑

- date, time이 구분된 ProposalDate를 사용하도록 Proposal 엔티티 변경
- ProposalDate를 반영한 Proposal 변경에 따른 OrderService 코드 수정